### PR TITLE
Message if there are errors getting steam data

### DIFF
--- a/steam.el
+++ b/steam.el
@@ -150,6 +150,8 @@ Entries already existing in the buffer will not be duplicated."
   (let ((link (steam-game-attribute game 'logo))
         (filename (concat steam-logo-dir "/img" (steam-game-attribute game 'appID) ".jpg")))
     (unless (file-exists-p filename)
+      ;; write-region throws an error if file is in a nonexistant directory
+      (unless (file-exists-p steam-logo-dir) (make-directory steam-logo-dir))
       (url-retrieve
        link
        (lambda (status filename buffer)

--- a/steam.el
+++ b/steam.el
@@ -38,14 +38,32 @@
 (defvar steam-username nil "The Steam username.")
 (defvar steam-logo-dir "steamlogos" "The dir where logos will be downloaded, relative to the org-file.")
 
+(defun steam-check-xml-response (xml)
+  "Check XML from steam for errors, return an error message if an error was detected, else nil."
+  (let ((error-node (xml-get-children xml 'error))
+	(games-node (xml-get-children xml 'games)))
+    (cond
+     (error-node
+      (format "Recieved response: '%s', are you sure your profile is public?"
+	       (car (last (car error-node)))))
+      ((not games-node) "Could not find games tag in response")
+      (t nil))))
+
 (defun steam-get-xml ()
   "Downloads the user's games as XML."
   (with-current-buffer
       (url-retrieve-synchronously (format "http://steamcommunity.com/id/%s/games?tab=all&xml=1"
                                           (url-hexify-string steam-username)))
     (goto-char url-http-end-of-headers)
-    (car (xml-get-children (car (xml-parse-region (point) (point-max)))
-                           'games))))
+    (let*
+	((response (car (xml-parse-region (point) (point-max))))
+	 (error-detected (steam-check-xml-response response)))
+      (if (not error-detected)
+	  (progn
+	    (message "Retrieved games successfully")
+	    (car (xml-get-children response 'games)))
+	(message error-detected)
+	nil))))
 
 (defun steam-game-attribute (game attribute)
   "From GAME, read an XML ATTRIBUTE."


### PR DESCRIPTION
Hi! <code>steam-get-xml</code> now tells the user if there was some problem receiving the xml (e.g. profile not public), or otherwise tells the user there was no problem with the xml.