### PR TITLE
Fix byte compilation warnings

### DIFF
--- a/steam.el
+++ b/steam.el
@@ -40,7 +40,8 @@
 (defvar steam-logo-dir "steamlogos" "The dir where logos will be downloaded, relative to the org-file.")
 
 (defun steam-check-xml-response (xml)
-  "Check XML from steam for errors, return an error message if an error was detected, else nil."
+  "Check XML from steam for errors.
+Return an error message if an error was detected, else nil."
   (let ((error-node (xml-get-children xml 'error))
         (games-node (xml-get-children xml 'games)))
     (cond

--- a/steam.el
+++ b/steam.el
@@ -31,6 +31,7 @@
 (require 'url)
 (require 'xml)
 (require 'cl-lib)
+(require 'org)
 
 (declare-function org-current-level "org")
 
@@ -178,7 +179,7 @@ Entries already existing in the buffer will not be duplicated."
 
 (defun steam-id-at-point ()
   "Get steam game id of link at point, if any."
-  (or (when (org-in-regexp org-bracket-link-regexp 1)
+  (or (when (org-in-regexp org-link-bracket-re 1)
         (let ((link (match-string-no-properties 1)))
           (when (string-match "elisp:(steam-launch-id \\([0-9]+\\))"
                               link)
@@ -187,7 +188,7 @@ Entries already existing in the buffer will not be duplicated."
 
 (defun steam-link-description ()
   "Get description of steam.el link at point, if any."
-  (or (when (org-in-regexp org-bracket-link-regexp 1)
+  (or (when (org-in-regexp org-link-bracket-re 1)
         (match-string-no-properties 2))
       (error "No Steam link at point")))
 


### PR DESCRIPTION
Hi, this pull request fixes the following byte compilation warnings (with emacs 29):
`Warning (comp): steam.el:41:8: Warning: docstring wider than 80 characters`
`Warning (comp): steam.el:181:28: Warning: reference to free variable ‘org-bracket-link-regexp’`
`Warning (comp): steam.el:190:28: Warning: reference to free variable ‘org-bracket-link-regexp’`
`Warning (comp): steam.el:199:4: Warning: the function ‘org-next-link’ is not known to be defined.`
`Warning (comp): steam.el:197:6: Warning: the function ‘org-previous-visible-heading’ is not known to be defined.`
`Warning (comp): steam.el:196:12: Warning: the function ‘org-at-heading-p’ is not known to be defined.`
`Warning (comp): steam.el:181:14: Warning: the function ‘org-in-regexp’ is not known to be defined.`