### PR TITLE
Add support for customize

### DIFF
--- a/steam.el
+++ b/steam.el
@@ -38,11 +38,21 @@
 
 (declare-function org-current-level "org")
 
+(defgroup steam nil
+  "Launch games in your Steam library from Emacs."
+  :group 'external
+  :link '(url-link :tag "GitHub" "https://github.com/Kungsgeten/steam.el"))
+
 (defvar steam-games nil "An XML file of the user's games on Steam.")
-(defvar steam-username nil "The Steam username.
+(defcustom steam-username nil "The Steam username.
 It refers to the text in the CUSTOM URL field
-in your Steam account profile settings.")
-(defvar steam-logo-dir "steamlogos" "The dir where logos will be downloaded, relative to the org-file.")
+in your Steam account profile settings."
+  :type 'string
+  :group 'steam)
+(defcustom steam-logo-dir "steamlogos"
+  "The dir where logos will be downloaded, relative to the org-file."
+  :type 'string
+  :group 'steam)
 
 (defun steam-check-xml-response (xml)
   "Check XML from steam for errors.


### PR DESCRIPTION
Hi, this pull request add a customize menu for  `steam-username` and `steam-logo-dir` and not for `steam-games` since i don't think it should be edited manually.

It allows to use customize to edit those variable and to use the :custom keyword from use-package since it didn't work well without it.
With the following code the username was not set at startup.
`(use-package steam
	:custom
	(steam-username "username"))`
