### PR TITLE
Add documentation about how to get the username

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,6 +15,8 @@
 
 =steam.el= can not get a list of your games unless your Steam profile is public. Visit https://steamcommunity.com/id/username/edit/settings (where =username= is replaced with your Steam username). Set your profile to /Public/ and make sure that /Game details/ is set to /Public/.
 
+Here =steam-username= refers to the text in the =CUSTOM URL= field in your Steam account profile settings (you need to set one if there is nothing there).
+
 * Usage
 
    - To launch a game: =M-x steam-launch=

--- a/steam.el
+++ b/steam.el
@@ -19,7 +19,7 @@
 ;; library into an org-mode file, in order to organize your games, and launch
 ;; them from there.  Run either `steam-insert-org-text' or
 ;; `steam-insert-org-images' (if you want the logotypes for the games in your
-;; org file). The logotypes will be saved locally (see variable `steam-logo-dir'
+;; org file).  The logotypes will be saved locally (see variable `steam-logo-dir'
 ;; into a folder relative to the org-file.
 
 ;;; Code:

--- a/steam.el
+++ b/steam.el
@@ -15,6 +15,9 @@
 ;;
 ;; (setq steam-username "your_username")
 ;;
+;; Here `steam-username' refers to the text in the CUSTOM URL field
+;; in your Steam account profile settings.
+;;
 ;; Then use `steam-launch' to play a game! You can also insert your steam
 ;; library into an org-mode file, in order to organize your games, and launch
 ;; them from there.  Run either `steam-insert-org-text' or

--- a/steam.el
+++ b/steam.el
@@ -38,7 +38,9 @@
 (declare-function org-current-level "org")
 
 (defvar steam-games nil "An XML file of the user's games on Steam.")
-(defvar steam-username nil "The Steam username.")
+(defvar steam-username nil "The Steam username.
+It refers to the text in the CUSTOM URL field
+in your Steam account profile settings.")
 (defvar steam-logo-dir "steamlogos" "The dir where logos will be downloaded, relative to the org-file.")
 
 (defun steam-check-xml-response (xml)


### PR DESCRIPTION
Hi, this pull request add a bit of documentation about `steam-username` in both the ReadMe and the docstrings.
I wrote that since when I used the package, I had some difficulties to find what should be the value of `steam-username` since I didn't have anything entered in `CUSTOM URL` in my profile settings and my username didn't work.

Though maybe instead of just adding a little bit of documentation the variable name should change for something like `steam-custom-url-id` to be clearer about what it is. What do you think?